### PR TITLE
Fire events without action name

### DIFF
--- a/src/Jobs/ProcessGitHubWebhookJob.php
+++ b/src/Jobs/ProcessGitHubWebhookJob.php
@@ -17,6 +17,7 @@ class ProcessGitHubWebhookJob extends ProcessWebhookJob
 
     public function handle()
     {
+        event("github-webhooks::{$this->webhookCall->eventName()}", $this->webhookCall);
         event("github-webhooks::{$this->webhookCall->eventActionName()}", $this->webhookCall);
 
         collect(config('github-webhooks.jobs'))


### PR DESCRIPTION
Dispatching jobs that have action names and those without is functioning correctly, but there is an issue with firing events. Only events with the action name are being fired, such as 'github-webhooks::issues.created', whereas 'github-webhooks::issues' is not.

I created a simple solution to this problem and added a test case that covers firing these events.