### PR TITLE
Add missing use statement for `Schema`

### DIFF
--- a/database/migrations/create_github_webhook_calls_table.php.stub
+++ b/database/migrations/create_github_webhook_calls_table.php.stub
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {


### PR DESCRIPTION
Hi 👋,

This PR adds a missing use statement to import `Schema`.