### PR TITLE
Remove duplicate property in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ class HandleIssueOpenedWebhookJob implements ShouldQueue
 {
     use InteractsWithQueue, Queueable, SerializesModels;
 
-    public GitHubWebhookCall $gitHubWebhookCall;
-
     public function __construct(
         public GitHubWebhookCall $webhookCall
     ) {}
@@ -211,8 +209,6 @@ use Spatie\GitHubWebhooks\Models\GitHubWebhookCall;
 class HandleIssueOpenedWebhookJob implements ShouldQueue
 {
     use InteractsWithQueue, Queueable, SerializesModels;
-
-    public GitHubWebhookCall $gitHubWebhookCall;
 
     public function __construct(
         public GitHubWebhookCall $webhookCall


### PR DESCRIPTION
I assume this is a left-over from previous code, since the same property is already defined in the constructor.