### PR TITLE
Fix implicit nullable

### DIFF
--- a/src/Models/GitHubWebhookCall.php
+++ b/src/Models/GitHubWebhookCall.php
@@ -29,7 +29,7 @@ class GitHubWebhookCall extends WebhookCall
         return "{$this->eventName()}.$actionName";
     }
 
-    public function payload(string $key = null): mixed
+    public function payload(?string $key = null): mixed
     {
         if (! is_null($key)) {
             return Arr::get($this->payload, $key);


### PR DESCRIPTION
I got this error from our linter:

```
Deprecated: Spatie\GitHubWebhooks\Models\GitHubWebhookCall::payload(): Implicitly marking parameter $key as nullable is deprecated, the explicit nullable type must be used instead in src/Models/GitHubWebhookCall.php on line 32
```

See https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

I ran the tests locally on php 8.4 and 8.5, and it all runs smoothly. Version 8.0 (as supported by composer.json) doesn't work with the dev-dependencies. But it shouldn't be an issue of course, this syntax is supported since 7.1.